### PR TITLE
Fix broken playbook runtime

### DIFF
--- a/vars/Ubuntu-18.04.yml
+++ b/vars/Ubuntu-18.04.yml
@@ -1,6 +1,6 @@
 ---
 __unattended_allowed_origins:
-  - "${distro_id}:${distro_codename}";
-  - "${distro_id}:${distro_codename}-security";
-  - "${distro_id}ESMApps:${distro_codename}-apps-security";
-  - "${distro_id}ESM:${distro_codename}-infra-security";
+  - '${distro_id}:${distro_codename}'
+  - '${distro_id}:${distro_codename}-security'
+  - '${distro_id}ESMApps:${distro_codename}-apps-security'
+  - '${distro_id}ESM:${distro_codename}-infra-security'


### PR DESCRIPTION
Remove quotes and semicolons from vars; the template automatically applies them.

Fixes #2 